### PR TITLE
changed how we find the coauthor, removing alternate_authors method

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -2,7 +2,6 @@ class AuthorsController < ApplicationController
 
   def show
     @author = Author.find(params[:id])
-    @alternate_authors = Author.alternate_authors(@author)
   end
 
   def destroy

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -2,9 +2,4 @@ class Author < ApplicationRecord
   has_many :author_books, dependent: :destroy
   has_many :books, through: :author_books
   validates_presence_of :name
-
-  def self.alternate_authors(author)
-    where.not(id: author.id)
-  end
-
 end

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -35,8 +35,10 @@
         <a href=<%= book_path(book) %> class="btn btn-primary"><%= book.title %></a>
         <section id="alternate-authors">
         <p>
-          <% @alternate_authors.map do |author|%>
-            Co-author: <%= link_to author.name, author_path(author), class:'book-author', id:'author-#{author.id}' %></p>
+          <% book.authors.map do |author| %>
+            <% if @author.name != author.name %>
+              <p>Co-author: <%= link_to author.name, author_path(author), class:'book-author', id:'author-#{author.id}' %></p>
+            <% end %>
           <% end %>
         </section>
         <p>Pages: <%= book.pages %></p>

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -9,15 +9,4 @@ RSpec.describe Author, type: :model do
     it { should have_many :author_books}
     it { should have_many(:books).through(:author_books)}
   end
-
-  describe "helper methods" do
-    it "can find co-authors" do
-      astronaut = Book.create(title: "An Astronaut's Guide to Life on Earth", pages: 884, year: 2013, cover_url: 'http://media.npr.org/assets/bakertaylor/covers/a/an-astronauts-guide-to-life-on-earth/9780316253017_custom-72b5b1e3d259fb604fee1401424db3c8cd04cfe0-s6-c30.jpg')
-      astronaut.authors << Author.find_or_create_by(name: 'Chris Hadfield')
-      astronaut.authors << Author.find_or_create_by(name: 'Martin Mercer')
-
-      expect(Author.alternate_authors(astronaut.authors[0])).to eq([astronaut.authors[1]])
-    end
-  end
-
 end


### PR DESCRIPTION
What does this PR do?
--
- removes alternate_authors method
- changes authors view to reflect that change